### PR TITLE
Update for newer libopencm3

### DIFF
--- a/c6021light/src/hal/stm32I2C.cpp
+++ b/c6021light/src/hal/stm32I2C.cpp
@@ -142,7 +142,6 @@ void freeI2CRXMessage(I2CMessagePtr_t msgPtr);
 
 void beginI2C(uint8_t slaveAddress, freertossupport::OsTask routingTask) {
   i2c_peripheral_disable(I2C1);
-  i2c_reset(I2C1);
 
   taskToNotify = routingTask;
 
@@ -153,7 +152,7 @@ void beginI2C(uint8_t slaveAddress, freertossupport::OsTask routingTask) {
   // Basic I2C configuration
   // i2c_set_speed(I2C1, i2c_speed_sm_100k, I2C_CR2_FREQ_36MHZ);
   i2c_set_standard_mode(I2C1);
-  i2c_set_clock_frequency(I2C1, I2C_CR2_FREQ_36MHZ);
+  i2c_set_clock_frequency(I2C1, 36);
   i2c_set_trise(I2C1, 36);
   i2c_set_dutycycle(I2C1, I2C_CCR_DUTY_DIV2);
   i2c_set_ccr(I2C1, 180);


### PR DESCRIPTION
* Remove call to i2c_reset()
* Use recommended magic number instead of I2C frequency define