### PR TITLE
Add I2C Turnout Address Remapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.vscode

--- a/c6021light/.vscode/settings.json
+++ b/c6021light/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "cmake.ctest.testExplorerIntegrationEnabled": false,
+    "testMate.cpp.test.executables": "../../c6021light-build-*/**/*{test,Test,TEST}*"
+}

--- a/c6021light/CMakeLists.txt
+++ b/c6021light/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.6)
+cmake_minimum_required (VERSION 3.10)
 project (c6021light)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/c6021light/CMakeLists.txt
+++ b/c6021light/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(c6021lightTest
     "test/unit/AccessoryPacketTest.cpp"
     "test/unit/SlotServer.cpp"
     "test/unit/VelocityConversion.cpp"
+    "test/unit/I2CForwarderTest.cpp"
     "test/integration/StatelessRouting.cpp"
     "test/integration/LnSwitchRequest.cpp"
     "test/integration/StopGoRequest.cpp"

--- a/c6021light/CMakePresets.json
+++ b/c6021light/CMakePresets.json
@@ -15,16 +15,26 @@
             "name": "Windows",
             "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/../../c6021light-build-windows"
+        },
+        {
+            "name": "osx",
+            "generator": "Xcode",
+            "binaryDir": "${sourceDir}/../../c6021light-build-xcode"
         }
     ],
     "buildPresets": [
         {
             "name": "Linux",
-            "configurePreset": "Linux"
+            "configurePreset": "Linux",
+            "jobs": 0
         },
         {
             "name": "Windows",
             "configurePreset": "Windows"
+        },
+        {
+            "name": "osx",
+            "configurePreset": "osx"
         }
     ]
 }

--- a/c6021light/platformio.ini
+++ b/c6021light/platformio.ini
@@ -13,7 +13,7 @@
 
 [env]
 lib_deps = 
-    https://github.com/deltaphi/RR32CanLibrary.git#5b1347d0d13b9b7d8baabdb6fb3d000f93dd89af
+    https://github.com/deltaphi/RR32CanLibrary.git#6eb083da899dcdfbef979f6280ec17ec7c9e5125
     https://github.com/deltaphi/LocoNet#c0fcf431981cb2bf5fdf443aa26b36a5241153cc
     https://github.com/deltaphi/AtomicRingBuffer#031b54c88bc00f96f1a53e09cc11deea0b1dce6a 
     https://github.com/deltaphi/FlashFairyPP#17db277a7f9156c498a01043096b4d007d49d57d

--- a/c6021light/platformio.ini
+++ b/c6021light/platformio.ini
@@ -13,7 +13,7 @@
 
 [env]
 lib_deps = 
-    https://github.com/deltaphi/RR32CanLibrary.git#a712cb5529ac9f7d23ef9c85a9422c12fdf5cfa3
+    https://github.com/deltaphi/RR32CanLibrary.git#5b1347d0d13b9b7d8baabdb6fb3d000f93dd89af
     https://github.com/deltaphi/LocoNet#c0fcf431981cb2bf5fdf443aa26b36a5241153cc
     https://github.com/deltaphi/AtomicRingBuffer#031b54c88bc00f96f1a53e09cc11deea0b1dce6a 
     https://github.com/deltaphi/FlashFairyPP#17db277a7f9156c498a01043096b4d007d49d57d

--- a/c6021light/src/DataModel.h
+++ b/c6021light/src/DataModel.h
@@ -1,6 +1,8 @@
 #ifndef __DATAMODEL_H__
 #define __DATAMODEL_H__
 
+#include <map>
+
 #include "MarklinI2C/Constants.h"
 #include "RR32Can/Constants.h"
 #include "tasks/RoutingTask/LocoNetSlotServer.h"
@@ -30,6 +32,8 @@ struct DataModel {
   tasks::RoutingTask::LocoNetSlotServer::SlotServerState lnSlotServerState =
       tasks::RoutingTask::LocoNetSlotServer::SlotServerState::DISABLED;
   bool generateI2CTurnoutResponse = false;
+
+  std::map<RR32Can::MachineTurnoutAddress, RR32Can::MachineTurnoutAddress> i2cTurnoutMap;
 
   template <typename T>
   T getValueForKey(uint8_t key) const {

--- a/c6021light/src/tasks/RoutingTask/I2CForwarder.cpp
+++ b/c6021light/src/tasks/RoutingTask/I2CForwarder.cpp
@@ -29,6 +29,8 @@ bool isMatchingTurnoutRailProtocol(const RR32Can::RailProtocol left,
     return true;
   } else if (left == RR32Can::RailProtocol::MM1 || left == RR32Can::RailProtocol::MM2) {
     return (right == RR32Can::RailProtocol::MM1 || right == RR32Can::RailProtocol::MM2);
+  } else {
+    return false;
   }
 }
 

--- a/c6021light/src/tasks/RoutingTask/I2CForwarder.cpp
+++ b/c6021light/src/tasks/RoutingTask/I2CForwarder.cpp
@@ -115,6 +115,7 @@ bool I2CForwarder::MakeRR32CanMsg(const MarklinI2C::Messages::AccessoryMsg& requ
 
     } else {
       printf("PowerOff for wrong decoder.\n");
+      return false;
     }
   }
   return true;

--- a/c6021light/src/tasks/RoutingTask/I2CForwarder.h
+++ b/c6021light/src/tasks/RoutingTask/I2CForwarder.h
@@ -29,7 +29,8 @@ class I2CForwarder final : public RoutingForwarder {
   RR32Can::MachineTurnoutAddress remapTurnoutAddress(const RR32Can::MachineTurnoutAddress& turnoutAddress) const;
 
  private:
-  RR32Can::MachineTurnoutAddress lastPowerOnTurnoutAddr;
+  RR32Can::MachineTurnoutAddress lastPowerOnTurnoutAddri2C;
+  RR32Can::MachineTurnoutAddress lastPowerOnTurnoutAddrRemapped;
   RR32Can::TurnoutDirection lastPowerOnDirection;
   DataModel* dataModel_{nullptr};
 };

--- a/c6021light/src/tasks/RoutingTask/I2CForwarder.h
+++ b/c6021light/src/tasks/RoutingTask/I2CForwarder.h
@@ -31,7 +31,7 @@ class I2CForwarder final : public RoutingForwarder {
  private:
   RR32Can::MachineTurnoutAddress lastPowerOnTurnoutAddr;
   RR32Can::TurnoutDirection lastPowerOnDirection;
-  DataModel* dataModel_;
+  DataModel* dataModel_{nullptr};
 };
 
 }  // namespace RoutingTask

--- a/c6021light/src/tasks/RoutingTask/I2CForwarder.h
+++ b/c6021light/src/tasks/RoutingTask/I2CForwarder.h
@@ -26,6 +26,8 @@ class I2CForwarder final : public RoutingForwarder {
 
   void sendI2CResponseIfEnabled(const MarklinI2C::Messages::AccessoryMsg& i2cMsg);
 
+  RR32Can::MachineTurnoutAddress remapTurnoutAddress(const RR32Can::MachineTurnoutAddress& turnoutAddress) const;
+
  private:
   RR32Can::MachineTurnoutAddress lastPowerOnTurnoutAddr;
   RR32Can::TurnoutDirection lastPowerOnDirection;

--- a/c6021light/test/integration/StatelessRouting.cpp
+++ b/c6021light/test/integration/StatelessRouting.cpp
@@ -105,7 +105,7 @@ class TurnoutRoutingWithRemappingFixture : public mocks::RoutingTaskFixture {
  public:
   constexpr static const RR32Can::TurnoutDirection direction = RR32Can::TurnoutDirection::GREEN;
   constexpr static const bool powerOn = true;
-  constexpr static const bool powerOff = true;
+  constexpr static const bool powerOff = false;
 
   void SetUp() {
     mocks::RoutingTaskFixture::SetUp();
@@ -117,12 +117,12 @@ class TurnoutRoutingWithRemappingFixture : public mocks::RoutingTaskFixture {
     dataModel.i2cTurnoutMap.insert({turnoutButton, turnoutRemapped});
   }
 
-  // Turnout should bey keyboard 2, switch 14 -> 16+14 = human(30)
+  // Turnout should bey keyboard 2, switch 14 -> 16+14 = human(30) (hex 1E, machine hex 1D)
   RR32Can::MachineTurnoutAddress turnoutButton{RR32Can::HumanTurnoutAddress{30}};
-  // Turnout off is 16+12 = human(28)
-  RR32Can::MachineTurnoutAddress turnoutOffAddress{RR32Can::HumanTurnoutAddress{28}};
+  // Turnout off is 16+12 = human(28) (hex 1C, machine hex 1B)
+  RR32Can::MachineTurnoutAddress turnoutOffAddress{DecoderBaseAddress(turnoutButton)};
 
-  // Address is remapped to Keyboard 3, switch 4 -> 16+16+4 = human(36);
+  // Address is remapped to Keyboard 3, switch 4 -> 16+16+4 = human(36); (hex 24, machine hex 23)
   RR32Can::MachineTurnoutAddress turnoutRemapped{RR32Can::HumanTurnoutAddress{36}};
 
   RR32Can::CanFrame canFrameOn{Turnout(false, MM2_Turnout(turnoutRemapped), direction, powerOn)};
@@ -174,7 +174,7 @@ TEST_F(TurnoutRoutingWithRemappingFixture, Remapped_Off) {
   // Setup expectations
   EXPECT_CALL(canTx, SendPacket(canFrameOff));
   hal::I2CMessage_t i2cResponseMessageOff =
-      MarklinI2C::Messages::AccessoryMsg::makeOutbound(turnoutOffAddress, direction, powerOn);
+      MarklinI2C::Messages::AccessoryMsg::makeOutbound(turnoutOffAddress, direction, powerOff);
   EXPECT_CALL(i2cHal, sendI2CMessage(i2cResponseMessageOff));
   EXPECT_CALL(lnTx, DoAsyncSend(LnPacketOff));
 

--- a/c6021light/test/integration/StatelessRouting.cpp
+++ b/c6021light/test/integration/StatelessRouting.cpp
@@ -101,10 +101,10 @@ INSTANTIATE_TEST_SUITE_P(TurnoutTest, TurnoutRoutingFixture,
                          Values(MM2_Turnout(0u), MM2_Turnout(1u), MM2_Turnout(5u), MM2_Turnout(10u),
                                 MM2_Turnout(42u), MM2_Turnout(100u), MM2_Turnout(255u)));
 
-using SenorTestParam_t = std::tuple<RR32Can::MachineTurnoutAddress, RR32Can::SensorState>;
+using SensorTestParam_t = std::tuple<RR32Can::MachineTurnoutAddress, RR32Can::SensorState>;
 
-class SenorRoutingFixture : public mocks::RoutingTaskFixture,
-                            public WithParamInterface<SenorTestParam_t> {
+class SensorRoutingFixture : public mocks::RoutingTaskFixture,
+                            public WithParamInterface<SensorTestParam_t> {
  public:
   void SetUp() {
     mocks::RoutingTaskFixture::SetUp();
@@ -118,9 +118,9 @@ class SenorRoutingFixture : public mocks::RoutingTaskFixture,
   lnMsg LnPacket{Ln_Sensor(sensor, newState)};
 };
 
-const RR32Can::MachineTurnoutAddress SenorRoutingFixture::ZeroAddress;
+const RR32Can::MachineTurnoutAddress SensorRoutingFixture::ZeroAddress;
 
-TEST_P(SenorRoutingFixture, SensorRequest_CANtoLocoNet) {
+TEST_P(SensorRoutingFixture, SensorRequest_CANtoLocoNet) {
   // Setup expectations
   EXPECT_CALL(lnTx, DoAsyncSend(LnPacket));
 
@@ -134,7 +134,7 @@ TEST_P(SenorRoutingFixture, SensorRequest_CANtoLocoNet) {
   routingTask.loop();
 }
 
-TEST_P(SenorRoutingFixture, SensorRequest_LocoNetToCAN) {
+TEST_P(SensorRoutingFixture, SensorRequest_LocoNetToCAN) {
   // Setup expectations
   canFrame.id.setResponse(true);
   EXPECT_CALL(canTx, SendPacket(canFrame));
@@ -151,7 +151,7 @@ TEST_P(SenorRoutingFixture, SensorRequest_LocoNetToCAN) {
 
 using Addr = RR32Can::MachineTurnoutAddress;
 
-INSTANTIATE_TEST_SUITE_P(SensorTest, SenorRoutingFixture,
+INSTANTIATE_TEST_SUITE_P(SensorTest, SensorRoutingFixture,
                          Combine(Values(Addr(0), Addr(1), Addr(2), Addr(3), Addr(4), Addr(10),
                                         Addr(100), Addr(255), Addr(0x7FF)),
                                  Values(RR32Can::SensorState::OPEN, RR32Can::SensorState::CLOSED)));

--- a/c6021light/test/unit/I2CForwarderTest.cpp
+++ b/c6021light/test/unit/I2CForwarderTest.cpp
@@ -3,22 +3,27 @@
 
 #include "tasks/RoutingTask/I2CForwarder.h"
 
-TEST(I2CForwarderTest, Remap_Unmapped) {
-  auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
+class I2CForwarderFixture: public ::testing::Test {
+public:
+  
   DataModel model;
-  i2cForwarder.init(model);
+  tasks::RoutingTask::I2CForwarder i2cForwarder;
+  
+  void SetUp() {
+    i2cForwarder.init(model);
 
+  }
+
+};
+
+TEST_F(I2CForwarderFixture, Remap_Unmapped) {
   const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
   const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
 
   EXPECT_EQ(actual, turnoutAddress);
 }
 
-TEST(I2CForwarderTest, Remap_Remapped) {
-  auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
-  DataModel model;
-  i2cForwarder.init(model);
-
+TEST_F(I2CForwarderFixture, Remap_Remapped) {
   const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
   const RR32Can::MachineTurnoutAddress expected{0xBBu};
 
@@ -29,11 +34,7 @@ TEST(I2CForwarderTest, Remap_Remapped) {
   EXPECT_EQ(actual, expected);
 }
 
-TEST(I2CForwarderTest, Remap_Umapped_Remapped_Unmapped) {
-  auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
-  DataModel model;
-  i2cForwarder.init(model);
-
+TEST_F(I2CForwarderFixture, Remap_Umapped_Remapped_Unmapped) {
   const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
   const RR32Can::MachineTurnoutAddress remappedAddress{0xBBu};
 

--- a/c6021light/test/unit/I2CForwarderTest.cpp
+++ b/c6021light/test/unit/I2CForwarderTest.cpp
@@ -5,6 +5,8 @@
 
 TEST(I2CForwarderTest, Remap_Unmapped) {
   auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
+  DataModel model;
+  i2cForwarder.init(model);
 
   const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
   const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
@@ -14,9 +16,7 @@ TEST(I2CForwarderTest, Remap_Unmapped) {
 
 TEST(I2CForwarderTest, Remap_Remapped) {
   auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
-
   DataModel model;
-
   i2cForwarder.init(model);
 
   const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};

--- a/c6021light/test/unit/I2CForwarderTest.cpp
+++ b/c6021light/test/unit/I2CForwarderTest.cpp
@@ -28,3 +28,27 @@ TEST(I2CForwarderTest, Remap_Remapped) {
 
   EXPECT_EQ(actual, expected);
 }
+
+TEST(I2CForwarderTest, Remap_Umapped_Remapped_Unmapped) {
+  auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
+  DataModel model;
+  i2cForwarder.init(model);
+
+  const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
+  const RR32Can::MachineTurnoutAddress remappedAddress{0xBBu};
+
+  {
+    const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
+    EXPECT_EQ(actual, turnoutAddress);
+  }
+  model.i2cTurnoutMap.insert({turnoutAddress, remappedAddress});
+  {
+    const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
+    EXPECT_EQ(actual, remappedAddress);
+  }
+  model.i2cTurnoutMap.erase(turnoutAddress);
+  {
+    const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
+    EXPECT_EQ(actual, turnoutAddress);
+  }
+}

--- a/c6021light/test/unit/I2CForwarderTest.cpp
+++ b/c6021light/test/unit/I2CForwarderTest.cpp
@@ -1,0 +1,30 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "tasks/RoutingTask/I2CForwarder.h"
+
+TEST(I2CForwarderTest, Remap_Unmapped) {
+  auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
+
+  const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
+  const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
+
+  EXPECT_EQ(actual, turnoutAddress);
+}
+
+TEST(I2CForwarderTest, Remap_Remapped) {
+  auto i2cForwarder = tasks::RoutingTask::I2CForwarder();
+
+  DataModel model;
+
+  i2cForwarder.init(model);
+
+  const RR32Can::MachineTurnoutAddress turnoutAddress{0xAAu};
+  const RR32Can::MachineTurnoutAddress expected{0xBBu};
+
+  model.i2cTurnoutMap.insert({turnoutAddress, expected});
+
+  const RR32Can::MachineTurnoutAddress actual{i2cForwarder.remapTurnoutAddress(turnoutAddress)};
+
+  EXPECT_EQ(actual, expected);
+}


### PR DESCRIPTION
Allows to set up a remapping from a given I2C address to any other address.